### PR TITLE
implement recurring tasks

### DIFF
--- a/src/main/java/tasks/Deadline.java
+++ b/src/main/java/tasks/Deadline.java
@@ -12,6 +12,8 @@ public class Deadline extends Task implements Comparable<Task> {
     private String[] split2;
     private LocalDate dueDate;
     private Integer timeCompare;
+    private String name;
+    private boolean isRecurring;
 
     /**
      * Constructs a new Deadline task with the user command and 'mark' status
@@ -24,6 +26,14 @@ public class Deadline extends Task implements Comparable<Task> {
         splitSlash = content.split("/", 2);
         split2 = splitSlash[1].split(" ", 3);
         timeCompare = Integer.parseInt(split2[2]);
+        this.isRecurring = false;
+        String[] title = splitSlash[0].split(" ", 3);
+        if (title[1].equals("recurring")) {
+            this.isRecurring = true;
+            name = title[2];
+        } else {
+            name = title[1] + " " + title[2];
+        }
         try {
             this.dueDate = LocalDate.parse(split2[1].replace("/", "-"));
         } catch (DateTimeParseException e) {
@@ -32,9 +42,14 @@ public class Deadline extends Task implements Comparable<Task> {
                 this.dueDate = LocalDate.parse(split2[1], formatter);
             } catch (DateTimeException ex) {
                 throw new DukeException("\n" + "DateTime wrong input format\n");
-                // this.dueDate = splitSlash[1];
             }
         }
+    }
+
+    public Deadline update(LocalDate newLocalDate) throws DukeException {
+        String newContent = String.format("%s/%s %s %s", splitSlash[0], split2[0],
+                newLocalDate.toString(), split2[2]);
+        return new Deadline(newContent, super.isMarked());
     }
 
     /**
@@ -71,16 +86,19 @@ public class Deadline extends Task implements Comparable<Task> {
         return timeCompare;
     }
 
+    public boolean isRecurring() {
+        return this.isRecurring;
+    }
+
     /**
      * @return The status of this task through a string
      */
     public String toString() {
-        String[] result = splitSlash[0].split(" ", 2);
         String dueDateString = dueDate.format(DateTimeFormatter.ofPattern("MMM d yyyy"));
         if (!super.isMarked()) {
-            return String.format("[D][ ] %s(by: %s %s)", result[1], dueDateString, split2[2]);
+            return String.format("[D][ ] %s(by: %s %s)", name, dueDateString, split2[2]);
         } else {
-            return String.format("[D][X] %s(by: %s %s)", result[1], dueDateString, split2[2]);
+            return String.format("[D][X] %s(by: %s %s)", name, dueDateString, split2[2]);
         }
     }
 }

--- a/src/main/java/tasks/Event.java
+++ b/src/main/java/tasks/Event.java
@@ -13,6 +13,8 @@ public class Event extends Task implements Comparable<Task> {
     private String[] endTime;
     private String startTime;
     private LocalDate localDate;
+    private String name;
+    private boolean isRecurring;
 
     /**
      * Constructs a new Event task with the specified user input.
@@ -20,13 +22,21 @@ public class Event extends Task implements Comparable<Task> {
      * @param content The user input to create an event
      * @param status  marked or unmarked
      */
-    public Event(String content, boolean status) throws DukeException {
+    public Event(String content, boolean status) {
         super(content, status);
         splitSlash = content.split("/", 2);
         startDate = splitSlash[1].split(" ", 3);
         String[] split2 = startDate[2].split("/", 2);
         startTime = split2[0];
         endTime = split2[1].split(" ", 2);
+        this.isRecurring = false;
+        String[] title = splitSlash[0].split(" ", 3);
+        if (title[1].equals("recurring")) {
+            this.isRecurring = true;
+            name = title[2];
+        } else {
+            name = title[1] + " " + title[2];
+        }
         try {
             this.localDate = LocalDate.parse(startDate[1].replace("/", "-"));
         } catch (DateTimeParseException e) {
@@ -37,6 +47,12 @@ public class Event extends Task implements Comparable<Task> {
                 this.startTime = startDate[1] + " " + split2[0];
             }
         }
+    }
+
+    public Event update(LocalDate newLocalDate) {
+        String newContent = String.format("%s/%s %s %s", splitSlash[0], startDate[0],
+                newLocalDate.toString(), startDate[2]);
+        return new Event(newContent, super.isMarked());
     }
 
     /**
@@ -73,16 +89,19 @@ public class Event extends Task implements Comparable<Task> {
         return Integer.parseInt(startTime.substring(0, startTime.length() - 1));
     }
 
+    public boolean isRecurring() {
+        return this.isRecurring;
+    }
+
     /**
      * @return a String message describing the event
      */
     public String toString() {
-        String[] result = splitSlash[0].split(" ", 2);
         String startDateString = localDate.format(DateTimeFormatter.ofPattern("MMM d yyyy")) + " " + startTime;
         if (!super.isMarked()) {
-            return String.format("[E][ ] %s(%s: %s%s: %s)", result[1], startDate[0], startDateString, endTime[0], endTime[1]);
+            return String.format("[E][ ] %s(%s: %s%s: %s)", name, startDate[0], startDateString, endTime[0], endTime[1]);
         } else {
-            return String.format("[E][X] %s(%s: %s%s: %s)", result[1], startDate[0], startDateString, endTime[0], endTime[1]);
+            return String.format("[E][X] %s(%s: %s%s: %s)", name, startDate[0], startDateString, endTime[0], endTime[1]);
         }
     }
 }

--- a/src/main/java/tasks/Task.java
+++ b/src/main/java/tasks/Task.java
@@ -9,6 +9,7 @@ public class Task implements Comparable<Task> {
     private boolean isMarked;
     private LocalDate localDate;
     private Integer timeCompare;
+    private boolean isRecurring = false;
 
     /**
      * Constructs a task with an initial status of not isMarked
@@ -28,6 +29,10 @@ public class Task implements Comparable<Task> {
         this.isMarked = status;
         this.localDate = LocalDate.now();
         this.timeCompare = 0;
+    }
+
+    public Task update(LocalDate localDate) throws DukeException {
+        return new Task(getContent(), isMarked());
     }
 
     /**
@@ -83,6 +88,10 @@ public class Task implements Comparable<Task> {
         } else {
             return this.getTimeCompare().compareTo(other.getTimeCompare());
         }
+    }
+
+    public boolean isRecurring() {
+        return this.isRecurring;
     }
 
     /**


### PR DESCRIPTION
users have to manually add in weekly repeating tasks.

This process of adding the same task every week is tedious. The recurring task functionality allow users to add repeating tasks only once, and it will be auto updated when past.

Let's check whether recurring tasks are past when user calls 'list'. If the recurring task is past (i.e. expired), we update the date of the task to the corresponding day of the week after the current day.

We only display one instance of the recurring task on the task list at any point of time to reduce cluttering.